### PR TITLE
Feature/#12/bonus

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,15 @@ You can use the option `-h` on each script to get help indications with the avai
 To modify the input text open the file located here "*datasets/input.txt*" and edit the input text
 * `python scripts/segment.py`
 
+To modify the input HTML open the file located here "*datasets/input.html*" and edit the input HTML
+* `python scripts/segment.py --html`
+
+The manual way to check if tags were inserted at the right place (mosly the end span tag because the start span tag insertion is flawed) is to store the result in a file like that
+* `python scripts/segment.py --html > result.html`
+
+Then you can run the following line to print the lines in the html where span tags were inserted
+* `python scripts/segment.py --html --debug`
+
 # Ideas that will not be tested
 * Tokenization to test the results with words instead of bag of characters
 * If words were used, word embeddings from word2vec, GloVe or fastText could have been used

--- a/config/configuration.ini
+++ b/config/configuration.ini
@@ -10,6 +10,7 @@ train         = training.json
 validation    = validation.json
 test          = testing.json
 input         = input.txt
+htmlInput     = input.html
 
 [MODEL]
 modelFolder = models

--- a/scripts/segment.py
+++ b/scripts/segment.py
@@ -17,16 +17,23 @@ conf.read(os.path.join(os.path.dirname(__file__), '..', 'config', 'configuration
 
 eosPunctRE = re.compile(r'[\.?!:;]')
 
-def loadText() -> str:
+def loadText(isHtml: bool) -> str:
   '''Load input text from a file
+
+  Args:
+    isHtml: Enable html processing, retrieve html input if activated
 
   Returns:
     The input text
   '''
   datasetFolderPath = os.path.join(os.path.dirname(__file__), '..',
                                    conf.get('DATASET', 'datasetFolder'))
+  if isHtml:
+    textFile = os.path.join(datasetFolderPath, conf.get('DATASET', 'htmlInput'))
+  else:
+    textFile = os.path.join(datasetFolderPath, conf.get('DATASET', 'input'))
   content = ''
-  with open(os.path.join(datasetFolderPath, conf.get('DATASET', 'input')), 'r') as inputFd:
+  with open(textFile, 'r') as inputFd:
     content = inputFd.read()
   return content
 
@@ -36,12 +43,16 @@ def main(args: argparse.Namespace) -> None:
   Args:
     args: An argument Namespace
   '''
-  text = loadText()
+  text = loadText(args.html)
   segmenter = Segmenter(args.ngram_size, args.html)
-  sentences = segmenter.segment(text)
+  result = segmenter.segment(text)
 
-  for sentence in sentences:
-    print(sentence)
+  if result:
+    if not args.html:
+      for sentence in result:
+        print(sentence)
+    else:
+      print(result)
 
 if __name__ == '__main__':
   parser = argparse.ArgumentParser()

--- a/scripts/segment.py
+++ b/scripts/segment.py
@@ -45,9 +45,9 @@ def main(args: argparse.Namespace) -> None:
   '''
   text = loadText(args.html)
   segmenter = Segmenter(args.ngram_size, args.html)
-  result = segmenter.segment(text)
+  result = segmenter.segment(text, args.debug)
 
-  if result:
+  if result and not args.debug:
     if not args.html:
       for sentence in result:
         print(sentence)
@@ -59,5 +59,7 @@ if __name__ == '__main__':
   parser.add_argument('--ngram-size', default=5, type=int, help='Character ngram size')
   parser.add_argument('--html', default=False, action='store_const', const=True,
                       help='Enable the html processing of the text')
+  parser.add_argument('--debug', default=False, action='store_const', const=True,
+                      help='Enable prompt debugging of the html feature')
   arguments = parser.parse_args()
   main(arguments)

--- a/srcs/Segmenter.py
+++ b/srcs/Segmenter.py
@@ -99,13 +99,14 @@ class Segmenter(object):
 
     return tokens
 
-  def segment(self, text: str) -> Union[List[str], str]:
+  def segment(self, text: str, debug: bool) -> Union[List[str], str]:
     '''Takes a text as input, preprocess into to find end-of-sentence tokens in it, predict if
     the token is an end of sentence. Then split the text into sentences with the selected
     end-of-sentence tokens and their indexes
 
     Args:
-      text: Input text to segment
+      text:   Input text to segment
+      debug:  Enables span insertion debugging
 
     Returns:
       A list of sentences or an html block with span tags for each sentence
@@ -148,6 +149,8 @@ class Segmenter(object):
 
         for i, token in enumerate(tokens):
           if predictions[i] == 1:
+            if debug:
+              print('Line index: {}\nContent: {}'.format(textIndex[1][0], textIndex[0]))
             # Consider that the end of the previous sentence is the beginning of a new one, even if
             # this assumption is false in an html file
             result = result[:startSentence] + '<span>' + result[startSentence:]

--- a/srcs/Segmenter.py
+++ b/srcs/Segmenter.py
@@ -24,28 +24,56 @@ conf = SafeConfigParser()
 conf.read(os.path.join(os.path.dirname(__file__), '..', 'config', 'configuration.ini'))
 
 class TextIndexParser(HTMLParser):
+  '''A class to parse HTML content, retrieve the inner content of tags
+
+  Attributes:
+    lines (list): A list of strings, each string is the inner content of a pair of tags
+  '''
   def __init__(self, *args, **kwargs) -> None:
     self.lines = []
     super(TextIndexParser, self).__init__(*args, **kwargs)
 
   def handle_data(self, data: str) -> None:
+    '''Function called at each tag, store each inner content with its start and end position
+
+    Args:
+      data: A tag inner content
+    '''
     if data.strip():
       start = self.getpos()
       end = (start[0], start[1] + len(data))
       self.lines.append((data, start, end))
 
   def clear(self) -> None:
+    '''Reset the internal storage of tags inner content
+    '''
     self.lines = []
 
-def yxToIndex(y: int, x: int, htmlLines: List[str]) -> int:
+  def error(self) -> None:
+    '''Overwritten because the linter would print errors, however the function is not documentated
+    in the standard api, that's why it is empty
+    '''
+    pass
+
+def yxToIndex(yIndex: int, xIndex: int, htmlLines: List[str]) -> int:
+  '''Transform a (y, x) index into a flat index in the raw html content
+
+  Args:
+    yIndex:     A line index
+    xIndex:     A character index within a line
+    htmlLines:  Html content split by new line
+
+  Returns:
+    An index in the raw html content
+  '''
   index = 0
   j = 0
 
-  while j < y:
+  while j < yIndex:
     index += len(htmlLines[j]) + 1
     j += 1
 
-  return index + x
+  return index + xIndex
 
 class Segmenter(object):
   '''A class to segment text or html into sentences


### PR DESCRIPTION
# Summary
Add the option to work with html content.
Unfortunately it's not as good as expected, sometimes the end index of sentence end is wrong when multiple sentences are on the same line in the HTML.
The start of sentence tag insertion method is flawed because it assumes that an end of sentence tag should open a tag for a new sentence.

# Changes
* Edit readme for usage
* Add html segmentation in Segmenter class
* Add html usage in segment script

# Related
Issues
- Closes #12

PR
* None

# Test
### Test code quality
* `./linter.sh` - you should check that the linter mark is 10/10

### If you already have a trained model then do the following
Edit *datasets/input.html* if you want to set your own HTML
* `python scripts/segment.py --html > result.html`
* `python scripts/segment.py --html --debug`
It will store the new html with span tags in `result.html`.
Then the second line will print all lines where a span tag has been inserted.